### PR TITLE
Add catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: shellImages
+  annotations:
+    github.com/project-slug: AndrienkoAleksandr/shellImages
+spec:
+  type: other
+  lifecycle: unknown
+  owner: user:default/andrienkoaleksandr


### PR DESCRIPTION
This PR adds a default catalog-info.yaml for Backstage.